### PR TITLE
Fix to allow it to work when name of app is specified and not null

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ BUG: request should not be set to global environment, so you need use request['f
     app = Sanic()
 
     jinja = SanicJinja2(app)
+    #
+    # Specify the package name, if templates/ dir is inside module
+    # jinja - SanicJinja2(app, pkg_name='sanicapp')
+    #
     # or setup later
     # jinja = SanicJinja2()
     # jinja.init_app(app)

--- a/sanic_jinja2/__init__.py
+++ b/sanic_jinja2/__init__.py
@@ -7,10 +7,11 @@ from jinja2 import Environment, PackageLoader
 
 
 class SanicJinja2:
-    def __init__(self, app=None, loader=None, **kwargs):
+    def __init__(self, app=None, loader=None, pkg_name=None, **kwargs):
         self.env = Environment(**kwargs)
         if app:
-            self.init_app(app, loader)
+            pkg_name = pkg_name or app.name
+            self.init_app(app, loader, pkg_name)
 
     def add_env(self, name, obj, scope='globals'):
         if scope == 'globals':
@@ -18,14 +19,14 @@ class SanicJinja2:
         elif scope == 'filters':
             self.env.filters[name] = obj
 
-    def init_app(self, app, loader=None):
+    def init_app(self, app, loader=None, pkg_name=None):
         if not hasattr(app, 'extensions'):
             app.extensions = {}
 
         app.extensions['jinja2'] = self
         app.jinja_env = self.env
         if not loader:
-            loader = PackageLoader(app.name, 'templates')
+            loader = PackageLoader(pkg_name, 'templates')
 
         self.env.loader = loader
         self.add_env('app', app)


### PR DESCRIPTION
Currently the jinja extension only works by chance.  

When no name is provided to Sanic, it defaults to the  module name.  Jinja is passed this 'module name' which it is expecting to be the name of the package, and it is.

However if you defined a name: `Sanic(name='My App')`, then 'My App' gets provided to jinja as the module/package name.

The patch allows you to specify the package name so jinja can find the templates directory.  This may be able to be figured out dynamically through introspection, but seems pretty difficult.