### PR TITLE
js block unused

### DIFF
--- a/example/templates/base.html
+++ b/example/templates/base.html
@@ -119,7 +119,6 @@
         ;
       })
     ;
-    {% block js %}{% endblock %}
     </script>
   </body>
 </html>


### PR DESCRIPTION
Currently js block isn't used; removing it and stashing it for later when you add more to this example is recommended.