### PR TITLE
Allow falsy request argument in update_request_context function

### DIFF
--- a/sanic_jinja2/__init__.py
+++ b/sanic_jinja2/__init__.py
@@ -21,6 +21,9 @@ def fake_trans(text, *args, **kwargs):
 
 
 def update_request_context(request, context):
+    if not request:
+       return
+
     if 'babel' in request.app.extensions:
         babel = request.app.babel_instance
         g = _make_new_gettext(babel._get_translations(request).ugettext)


### PR DESCRIPTION
For example we flask's [render_template](http://flask.pocoo.org/docs/1.0/api/#flask.render_template) with args `(template_name_or_list, **context)`

If we migrate to sanic, it would be cool to wrap SanicJinja2's render method under `render_template`:
```python
from sanic_jinja2 import SanicJinja2

jinja = SanicJinja2(app)

def render_template(template, **context):
    return jinja.render(template, None, **context)
```