### PR TITLE
Fix flash messages with an empty session

### DIFF
--- a/sanic_jinja2/__init__.py
+++ b/sanic_jinja2/__init__.py
@@ -173,7 +173,7 @@ class SanicJinja2:
     def _flash(self, request, message, category="message"):
         """need sanic_session extension"""
         sess = self.session(request)
-        if sess:
+        if sess is not None:
             flashes = sess.get("_flashes", [])
             flashes.append((category, message))
             sess["_flashes"] = flashes


### PR DESCRIPTION
Hi @lixxu 

Seems I've found a bug. 
When I tried to use flash messages with the empty Session it doesn't work.

It can be reproduced with an example from the repo. The first time when we open the page there are no messages and they appear only after refresh.

Please, take a look on the PR.